### PR TITLE
Sticky scoring and order fixes on judging

### DIFF
--- a/src/components/JudgingScoring.vue
+++ b/src/components/JudgingScoring.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="originalJudging && criteria && submission">
+    <div v-if="originalJudging && criteria && submission" class="judging-scoring">
         <textarea
             id="comment"
             v-model="newGeneralComment"
@@ -125,3 +125,10 @@ export default defineComponent({
     },
 });
 </script>
+
+<style lang="scss">
+.judging-scoring {
+    position: sticky;
+    top: 1.5rem;
+}
+</style>

--- a/src/components/JudgingTable.vue
+++ b/src/components/JudgingTable.vue
@@ -101,8 +101,8 @@ export default defineComponent({
                 submissions.sort((a, b) => {
                     const anomA = a.anonymisedAs?.toUpperCase();
                     const anomB = b.anonymisedAs?.toUpperCase();
-                    if (anomA < anomB) return this.sortDesc ? -1 : 1;
-                    if (anomA > anomB) return this.sortDesc ? 1 : -1;
+                    if (anomA < anomB) return this.sortDesc ? 1 : -1;
+                    if (anomA > anomB) return this.sortDesc ? -1 : 1;
 
                     return 0;
                 });


### PR DESCRIPTION
This PR resolves:

- order judging by anom name by default to avoid switching order everytime
- make the scoring panel fixed when scrolling "it kinda sucks when i want to rate bottom diffs"